### PR TITLE
Build fixes after latest changes

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -8,8 +8,8 @@
 
 CC    = -no-pie
 GTK   = `pkg-config --libs --cflags gtk+-2.0`
-LIBS  = `pkg-config --libs libswscale libavutil`
-JPEG  = -I/opt/libjpeg-turbo/include /opt/libjpeg-turbo/lib`getconf LONG_BIT`/libturbojpeg.a
+LIBS  = `pkg-config --libs --cflags libswscale libavutil`
+JPEG  = -lturbojpeg
 SRC      = src/connection.c src/decoder.c
 NO_WARN  = -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast
 

--- a/linux/README.md
+++ b/linux/README.md
@@ -3,14 +3,12 @@ Linux Client
 
 ## Building
 
-Download and install libjpeg-turbo binaries (should go into /opt/libjpeg-turbo):
-https://github.com/libjpeg-turbo/libjpeg-turbo/releases
-
-Install the following dependencies
+Install the following dependencies (Ubuntu):
 ```
 gtk+-2.0
 libavutil-dev
 libswscale-dev
+libturbojpeg0-dev
 ```
 
 Run `make`


### PR DESCRIPTION
1. Fedora ffmpeg contains libraries in `/usr/include/ffmpeg` instead of `/usr/include`. If you run this script on system without `/usr/include/fmpeg` it'll just work as before - so no problem here with additional path in such systems.

2. Updated Readme. In https://github.com/aramg/droidcam/commit/c40c3c1b89d1cb07f5591cfadf2f282ea503b231 you moved from `libjpeg-turbo` to `turbojpeg` which are totally different libraries. As I checked, `libturbojpeg-dev` exists in Ubuntu: https://packages.ubuntu.com/search?keywords=libturbojpeg&searchon=names