### PR TITLE
Improve instructions in README

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -3,8 +3,9 @@ Linux Client
 
 ## Building
 
-Download and install libjpeg-turbo binaries (should go into /opt/libjpeg-turbo):
-https://github.com/libjpeg-turbo/libjpeg-turbo/releases
+Download and install the official libjpeg-turbo binaries, i.e. `libjpeg-turbo-official_2.0.4_amd64.deb` or —`.rpm` (as appropriate for your distribution) by visiting the [2.0.4 release](https://github.com/libjpeg-turbo/libjpeg-turbo/releases) GitHub page and following the SourceForge link.
+
+The files should automatically install into `/opt/libjpeg-turbo`.
 
 Install the following dependencies
 ```
@@ -13,8 +14,9 @@ libavutil-dev
 libswscale-dev
 libasound2-dev
 libspeex-dev
+dkms  (if supported)
 ```
 
 Run `make`
 
-To install then, use either the `install` or `install-dkms` scripts [depending on the fact your system supports DKMS](./README-DKMS.md).
+To install, as superuser (i.e. with the `sudo` command) use either the `install` or `install-dkms` script [depending on whether or not your system supports DKMS](./README-DKMS.md).


### PR DESCRIPTION
I found a few things unclear regarding `libjpeg-turbo`: whether we should follow the SourceForge link to get the binaries, and whether they would automatically be installed to `/opt/` or if we would need to move them there. Thus I made things more explicit.

I also needed to install the `dkms` package, so I added that to dependencies. (I'm using Ubuntu 20.04.)

I hope these changes make it easier for people to install. Thanks for the awesome product!!!