### PR TITLE
Makefile: allow to modify how to link to libusbmuxd

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -17,6 +17,7 @@ LIBAV = `pkg-config --libs --cflags libswscale libavutil`
 LIBS  =  -lspeex -lasound -lpthread -lm
 JPEG  = -I$(JPEG_INCLUDE) $(JPEG_LIB)/libturbojpeg.a
 SRC      = src/connection.c src/settings.c src/decoder*.c src/av.c src/usb.c
+USBMUXD = -lusbmuxd
 
 all: droidcam-cli droidcam
 
@@ -27,7 +28,7 @@ package: clean all
 	zip -x *.png src/ src/* Makefile -r droidcam_`date +%s`.zip ./*
 
 else
-LIBS += -lusbmuxd
+LIBS += $(USBMUXD)
 endif
 
 gresource: .gresource.xml icon2.png


### PR DESCRIPTION
On distros like Arch Linux, libusbmuxd is installed as libusbmuxd-2.0,
so building is currently broken. With this commit, building works again,
if one specifies USBMUXD=-lusbmuxd-2.0 parameter.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>