### PR TITLE
Use mkrpm in dkms if on rpm-based release

### DIFF
--- a/linux/install-dkms
+++ b/linux/install-dkms
@@ -48,7 +48,11 @@ setup_dkms_module() {
 
     dkms build -m ${V4L2_LOOPBACK_DC} -v ${V4L2_LOOPBACK_VERSION}
     dkms install -m ${V4L2_LOOPBACK_DC} -v ${V4L2_LOOPBACK_VERSION}
-    dkms mkdeb -m ${V4L2_LOOPBACK_DC} -v ${V4L2_LOOPBACK_VERSION}
+    if [ -f /etc/redhat-release ]; then
+        dkms mkrpm -m ${V4L2_LOOPBACK_DC} -v ${V4L2_LOOPBACK_VERSION}
+    else
+        dkms mkdeb -m ${V4L2_LOOPBACK_DC} -v ${V4L2_LOOPBACK_VERSION}
+    fi
 }
 
 copy_uninstall_script() {


### PR DESCRIPTION
Without this, it will try to run dkms mkdeb which is useless in a Red Hat based distribution. `/etc/redhat-release` ought to find most distributions based on RPM.