### PR TITLE
Upstream v4l2loopback compatibility

### DIFF
--- a/linux/src/decoder_v4l2.c
+++ b/linux/src/decoder_v4l2.c
@@ -42,8 +42,8 @@ int find_droidcam_v4l() {
             continue;
         }
 
-        printf("Device %s is '%s'\n", v4l2_device, v4l2cap.card);
-        if (0 == strncmp((const char*) v4l2cap.card, "Droidcam", 8)) {
+        printf("Device %s is '%s' @ %s\n", v4l2_device, v4l2cap.card, v4l2cap.bus_info);
+        if (0 == strncmp((const char*) v4l2cap.bus_info, "platform:v4l2loopback", 20)) {
             printf("Opened %s, fd:%d\n", v4l2_device, droidcam_device_fd);
             return droidcam_device_fd;
         }


### PR DESCRIPTION
These patches alleviate the need for the v4l2loopback_dc module.

Essentially, it allows droidcam to work without setting the format during init:
https://github.com/aramg/droidcam/blob/master/linux/v4l2loopback/v4l2loopback-dc.c#L1900-L1914

The format can be set using v4l2loopback-ctl.

In case the v4l2loopback_dc module is used the behavior is unchanged.