### PR TITLE
add option to select specific adb device

### DIFF
--- a/linux/src/droidcam-cli.c
+++ b/linux/src/droidcam-cli.c
@@ -73,6 +73,8 @@ static inline void usage(int argc, char *argv[]) {
     "\n"
     " -size=WxH   Specify video size (when using the regular v4l2loopback module)\n"
     "             Ex: 640x480, 1280x720, 1920x1080\n"
+    " -s <serial> Specify Android serial number (when adb has multiple devices)\n"
+    "             (only takes effect if connecting via adb)\n"
     "\n"
     "Enter '?' for list of commands while streaming.\n"
     ,
@@ -99,6 +101,10 @@ static void parse_args(int argc, char *argv[]) {
             }
             if (argv[i][0] == '-' && argv[i][1] == 'v') {
                 v_running = 1;
+                continue;
+            }
+            if (argv[i][0] == '-' && argv[i][1] == 's' && argv[i][2] == '\0') {
+                sprintf(g_settings.serial_number, "-s %s", argv[++i]);
                 continue;
             }
             if (argv[i][0] == '-' && argv[i][1] == 's' && argv[i][3] == 'z') {
@@ -204,7 +210,7 @@ int main(int argc, char *argv[]) {
         SOCKET videoSocket = INVALID_SOCKET;
         if (g_settings.connection == CB_RADIO_WIFI || g_settings.connection == CB_RADIO_ADB || g_settings.connection == CB_RADIO_IOS) {
 
-            if (g_settings.connection == CB_RADIO_ADB && CheckAdbDevices(g_settings.port) < 0)
+            if (g_settings.connection == CB_RADIO_ADB && CheckAdbDevices(g_settings.port, g_settings.serial_number) < 0)
                 return 1;
 
             if (g_settings.connection == CB_RADIO_IOS) {
@@ -226,7 +232,7 @@ int main(int argc, char *argv[]) {
     if (a_running){
         printf("Audio: %s\n", snd_device);
         if (!v_running) {
-            if (g_settings.connection == CB_RADIO_ADB && CheckAdbDevices(g_settings.port) != 0)
+            if (g_settings.connection == CB_RADIO_ADB && CheckAdbDevices(g_settings.port, g_settings.serial_number) != 0)
                 return 1;
         }
 

--- a/linux/src/settings.h
+++ b/linux/src/settings.h
@@ -28,6 +28,7 @@ enum control_code {
 struct settings {
     char ip[32];
     int port;
+    char serial_number[32];
     int audio;
     int video;
     int connection; // Connection type
@@ -44,6 +45,7 @@ void SaveSettings(struct settings* settings);
 #define ERROR_DEVICE_OFFLINE  -4
 #define ERROR_DEVICE_NOTAUTH  -5
 int CheckAdbDevices(int port);
+int CheckAdbDevices(int port, const char *serial);
 int CheckiOSDevices(int port);
 void FreeUSB();
 

--- a/linux/src/usb.c
+++ b/linux/src/usb.c
@@ -7,6 +7,11 @@
 #include "settings.h"
 
 int CheckAdbDevices(int port) {
+	const char *serial = "";
+	return CheckAdbDevices(port, serial);
+}
+
+int CheckAdbDevices(int port, const char *serial) {
 	char buf[256];
 	FILE* pipe;
 	int rc = system("adb start-server");
@@ -48,7 +53,7 @@ EXIT:
 	dbgprint("CheckAdbDevices rc=%d\n", rc);
 
 	if (rc == NO_ERROR) {
-		sprintf(buf, "adb forward tcp:%d tcp:%d", port, port);
+		sprintf(buf, "adb %s forward tcp:%d tcp:%d", serial, port, port);
 		rc = system(buf);
 		if (WEXITSTATUS(rc) != 0){
 			rc = ERROR_ADDING_FORWARD;


### PR DESCRIPTION
If you have multiple Android devices connected, the only way to use droidcam is via environment variables:
```sh
ANDROID_SERIAL=<serial> droidcam adb <port>
```
To find this option, one needs to read through `adb(1)`. Adding the option to DC directly makes it much more accessible:
```sh
droidcam -s <serial> adb <port>
```
With the `g_settings` struct, I believe these changes could be added to the GUI as well with relative ease.

Also, I decided to put the `-s` flag directly in `g_settings.serial_number`, so the setting can just be `sprintf`'d into any adb command.